### PR TITLE
Use npm scripts arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
     "build": "gulp & npm run browserify:build & npm run rollup:build & npm run webpack:build",
     "browserify:build": "browserify -g uglifyify Source/scripts/app-browserify.js -o wwwroot/bundle-browserify-npm.js",
     "rollup:build": "rollup -c",
-    "rollup:watch": "rollup -cw 'Source/scripts/**/*'",
+    "rollup:watch": "npm run rollup:build -- --watch",
     "webpack:build": "webpack --config webpack.config.js",
-    "webpack:watch": "webpack --config webpack.config.js --watch"
+    "webpack:watch": "npm run webpack:build -- --watch"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
By using [npm scripts arguments](https://docs.npmjs.com/cli/run-script) you can make the configuration a bit more DRY.

I also couldn't find any documentation on the [rollup-watch](https://github.com/rollup/rollup-watch) source files argument, so I removed that part and it still seems to be working. :)